### PR TITLE
Handle NULL in eta and progress as not printing

### DIFF
--- a/printers.php
+++ b/printers.php
@@ -15,7 +15,10 @@ function format_time($t)
 
 function print_eta($f, $arr, $progress)
 {
-  if (count($arr) == 3)
+  if ($arr === NULL)
+  {
+    fprintf($f, "Not printing");
+  } elseif (count($arr) == 3)
   {
     fprintf($f, "%s / %s, ", format_time($arr[0]), format_time($arr[1]));
     // $arr[2] (i.e. progress) seems to be polymorphic


### PR DESCRIPTION
Before this change when printer finished printing web UI stopped displaying any status. On HTTP level printers.php responded with HTTP Error 500 Internal Server Error.

Script produced following error:

    PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value)
    must be of type Countable|array, null given

In printrun's code
https://github.com/kliment/Printrun/blob/b3a9e8003522589a40f5041b30726da743db9596/printrun/rpc.py#L73-L77 it is obvious that when printer is not printing "eta" and "progress" fields are None (in python) or NULL (in PHP).

After this change a message "Not printing" is displayed in ETA section of the page.