### PR TITLE
fswebcam as an alternative command to capture webcam images

### DIFF
--- a/camera.php
+++ b/camera.php
@@ -19,9 +19,10 @@ header("Pragma: no-cache");
 header("Location: {$img}");
 ob_flush(); flush();
 
-$video_dev = $video_dev_pref . $id;
-if (!in_array($video_dev, $video_dev_blacklist))
-{
+$cameras = getCameras($video_dev_glob, $rulesets);
+if (array_key_exists(strval($id), $cameras)) {
+  $camera = $cameras[$id];
+
   // generate new shot after redirect
   if (!file_exists($img) || (time() - filemtime($img) > $delay))
   {
@@ -30,16 +31,11 @@ if (!in_array($video_dev, $video_dev_blacklist))
     {
       if (!file_exists($img) || (time() - filemtime($img) > $delay))
       {
-        if (!array_key_exists($video_dev, $fwswebcam_args)) {
-          $command = "streamer -q -c {$video_dev} -b 16 -s {$img_res} -o {$tmp}";
-        } else {
-          $args = array_map('escapeshellarg', $fwswebcam_args[$video_dev]);
-          $command = "fswebcam -q --no-banner --no-timestamp --device {$video_dev} --resolution {$img_res} --save {$tmp} ". implode(' ', $args);
-        }
+        $command = "streamer -q -c {$camera['devicePath']} -b 16 -s {$img_res} -o {$tmp}";
         exec($command, $output, $retval);
         if ($retval == 0)
         {
-            rename($tmp, $img);
+          rename($tmp, $img);
         }
       }
       flock($fp, LOCK_UN);

--- a/camera.php
+++ b/camera.php
@@ -31,7 +31,12 @@ if (array_key_exists(strval($id), $cameras)) {
     {
       if (!file_exists($img) || (time() - filemtime($img) > $delay))
       {
-        $command = "streamer -q -c {$camera['devicePath']} -b 16 -s {$img_res} -o {$tmp}";
+        if (!isset($camera["fswebcam_args"])) {
+          $command = "streamer -q -c {$camera['devicePath']} -b 16 -s {$img_res} -o {$tmp}";
+        } else {
+          $args = array_map('escapeshellarg', $camera["fswebcam_args"]);
+          $command = "fswebcam -q --no-banner --no-timestamp --device {$camera['devicePath']} --resolution {$img_res} --save {$tmp} ". implode(' ', $args);
+        }
         exec($command, $output, $retval);
         if ($retval == 0)
         {

--- a/camera.php
+++ b/camera.php
@@ -19,7 +19,8 @@ header("Pragma: no-cache");
 header("Location: {$img}");
 ob_flush(); flush();
 
-if (!in_array($video_dev_pref . $id, $video_dev_blacklist))
+$video_dev = $video_dev_pref . $id;
+if (!in_array($video_dev, $video_dev_blacklist))
 {
   // generate new shot after redirect
   if (!file_exists($img) || (time() - filemtime($img) > $delay))
@@ -29,7 +30,13 @@ if (!in_array($video_dev_pref . $id, $video_dev_blacklist))
     {
       if (!file_exists($img) || (time() - filemtime($img) > $delay))
       {
-        exec("streamer -q -c /dev/video{$id} -b 16 -s {$img_res} -o {$tmp}", $output, $retval);
+        if (!array_key_exists($video_dev, $fwswebcam_args)) {
+          $command = "streamer -q -c {$video_dev} -b 16 -s {$img_res} -o {$tmp}";
+        } else {
+          $args = array_map('escapeshellarg', $fwswebcam_args[$video_dev]);
+          $command = "fswebcam -q --no-banner --no-timestamp --device {$video_dev} --resolution {$img_res} --save {$tmp} ". implode(' ', $args);
+        }
+        exec($command, $output, $retval);
         if ($retval == 0)
         {
             rename($tmp, $img);

--- a/config.php
+++ b/config.php
@@ -27,6 +27,16 @@ $rulesets = [
     ],
     'action' => 'ignore'
   ],
+  [
+    'match_rules' => [
+      ["ID_V4L_CAPABILITIES", ":capture:"],
+      ["ID_MODEL_ID", "704d"],
+      ["ID_VENDOR_ID", "0458"],
+    ],
+    'fswebcam_args' => [
+      "--s", "45"
+    ],
+  ]
 ];
 
 

--- a/config.php
+++ b/config.php
@@ -23,6 +23,12 @@ $img_res_full = "1280x720";
 $rulesets = [
   [
     'match_rules' => [
+      ["ID_MODEL", "Integrated_Camera"]
+    ],
+    'action' => 'ignore'
+  ],
+  [
+    'match_rules' => [
       ["ID_V4L_CAPABILITIES", ":"],
     ],
     'action' => 'ignore'

--- a/config.php
+++ b/config.php
@@ -13,19 +13,22 @@ $def_port = 7978;
 
 $delay = 2; // how long to cache cameras output before new shot is captured
 $cache_delay = 2; // how long to cache in browser in seconds before refresh is needed
-$video_dev_pref = "/dev/video";
+$video_dev_glob = "/dev/video*";
 //$video_dev_blacklist = array("/dev/video0", "/dev/video1");
 $video_dev_blacklist = array();
 $page_title = "3D printer status";
 // resolution of images
 $img_res_preview = "320x240";
 $img_res_full = "1280x720";
-// arguments of fwswebcam indexed by device file names of cameras to apply them to
-$fwswebcam_args = array(
-    "/dev/video8" => array(
-        "--skip", "45",
-    )
-);
+$rulesets = [
+  [
+    'match_rules' => [
+      ["ID_V4L_CAPABILITIES", ":"],
+    ],
+    'action' => 'ignore'
+  ],
+];
+
 
 // safety stop when searching for pronterfaces, if anything goes bad
 // do not probe for more than NUM pronterfaces, under normal conditions

--- a/config.php
+++ b/config.php
@@ -20,6 +20,12 @@ $page_title = "3D printer status";
 // resolution of images
 $img_res_preview = "320x240";
 $img_res_full = "1280x720";
+// arguments of fwswebcam indexed by device file names of cameras to apply them to
+$fwswebcam_args = array(
+    "/dev/video8" => array(
+        "--skip", "45",
+    )
+);
 
 // safety stop when searching for pronterfaces, if anything goes bad
 // do not probe for more than NUM pronterfaces, under normal conditions

--- a/devices.php
+++ b/devices.php
@@ -87,6 +87,13 @@ function processVideoDevicesInfo($videoDevicesInfo, $rulesets) {
         $includeDevice = false;
         break;
       }
+
+      // Add additional args for fwswebcam if any.
+      if (isset($rules['fswebcam_args'])) {
+        echo "<!-- has fswebcam_args -->\r\n";
+        $deviceInfo['fswebcam_args'] = $rules['fswebcam_args'];
+      }
+
       $rule_index += 1;
     }
 

--- a/devices.php
+++ b/devices.php
@@ -1,0 +1,124 @@
+<?php
+require("config.php");
+
+/**
+ * Gets the information for a single device using udevadm.
+ *
+ * @param string $devicePath The path to the device.
+ * @return array An associative array of the device's udevadm data.
+ */
+function getDeviceInfo($devicePath) {
+  $info = [];
+  $info['devicePath'] = $devicePath;
+
+  // Execute the udevadm command to get environment info for the device
+  $udevOutput = shell_exec("udevadm info --query=env --name=" . escapeshellarg($devicePath));
+
+  // Split the output into lines, then iterate and parse each line
+  $udevLines = explode("\n", $udevOutput);
+  foreach ($udevLines as $line) {
+    // Each line is in the form of KEY=value
+    if (!empty($line)) {
+      list($key, $value) = explode('=', $line, 2);
+      $info[$key] = $value;
+    }
+  }
+
+  return $info;
+}
+
+/**
+ * Retrieves information for all video devices on the system.
+ *
+ * @param string $video_dev_glob Glob pattern to match video devices.
+ * @return array A list of associative arrays containing udevadm data for each device.
+ */
+function getAllVideoDeviceInfo($video_dev_glob) {
+  $videoDevicePaths = glob($video_dev_glob);
+  $allDeviceInfo = [];
+
+  foreach ($videoDevicePaths as $devicePath) {
+    // Get info for the device and add it to the main array
+    $allDeviceInfo[] = getDeviceInfo($devicePath);
+  }
+
+  return $allDeviceInfo;
+}
+
+/**
+ * Processes video device information with given rules.
+ *
+ * @param array $videoDevicesInfo Array of video devices info.
+ * @param array $rulesets Array of rulesets containing match rules, additional attributes, and actions.
+ * @return array Processed array of video devices info.
+ */
+function processVideoDevicesInfo($videoDevicesInfo, $rulesets) {
+  $processedDevices = [];
+
+  foreach ($videoDevicesInfo as $deviceInfo) {
+    $includeDevice = true;
+    echo "<!-- processing device: {$deviceInfo['devicePath']} -->\r\n";
+    $rule_index = 0;
+    foreach ($rulesets as $rules) {
+      $matched = true;
+      foreach ($rules['match_rules'] as $rule) {
+        $attribute = $rule[0];
+        $value = $rule[1];
+
+        if (!isset($deviceInfo[$attribute]) || $deviceInfo[$attribute] != $value) {
+          $matched = false;
+          echo "<!-- - not match of rule: $attribute = $value -->\r\n";
+          break;
+        }
+      }
+      if (!$matched) {
+        $rule_index += 1;
+        continue;
+      }
+
+      echo "<!-- matched rule #$rule_index -->\r\n";
+      /*echo "<!-- matching rule:\r\n";
+      print_r($rules);
+      echo "-->\r\n";*/
+
+      // Check for 'ignore' action.
+      if (isset($rules['action']) && $rules['action'] === 'ignore') {
+        echo "<!-- = action = 'ignore' -->\r\n";
+        $includeDevice = false;
+        break;
+      }
+      $rule_index += 1;
+    }
+
+    if ($includeDevice) {
+      echo "<!-- = including device -->\r\n";
+      // ID used to select camera.
+      if (substr($deviceInfo['devicePath'], 0, strlen('/dev/video')) == '/dev/video') {
+        $deviceInfo["id"] = substr($deviceInfo['devicePath'], strlen('/dev/video'));
+        echo "<!-- - device id: {$deviceInfo['id']}. -->\r\n";
+      } else {
+        echo "<!-- Failed to set id for {$deviceInfo['devicePath']}.\r\n";
+        echo "It does not have prefix /dev/video -->\r\n";
+      }
+
+      if (isset($deviceInfo["id"])) {
+        $processedDevices[$deviceInfo["id"]] = $deviceInfo;
+      } else {
+        $processedDevices[] = $deviceInfo;
+      }
+    }
+  }
+
+  return $processedDevices;
+}
+
+/**
+ * Main function to collect, process and ignore all devices.
+ *
+ * @return array Processed video devices info with the defined rules.
+ */
+function getCameras($video_dev_glob, $rulesets) {
+  $videoDevicesInfo = getAllVideoDeviceInfo($video_dev_glob);
+
+  return processVideoDevicesInfo($videoDevicesInfo, $rulesets);
+}

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 require("config.php");
+require("devices.php");
 $camera = @intval($_GET["camera"]);
 $fullscreen = isset($_GET["fullscreen"]);
 ?>
@@ -37,38 +38,8 @@ if ($homepage)
 
 <div id="cameras">
   <?php
-
-    function findVideoCaptureBlock(array $lines) {
-      $isCapturing = false;
-
-      foreach ($lines as $line) {
-        if (!$isCapturing && preg_match('/^video capture/i', $line)) {
-          $isCapturing = true;
-        } elseif ($isCapturing) {
-          if (strpos($line, 'VIDEO_CAPTURE') !== false) {
-            return true;
-          }
-          if (preg_match('/^controls/i', $line)) {
-            $isCapturing = false;
-          }
-        }
-      }
-
-      return false;
-    }
-
     if (!$fullscreen) {
-      $cameras = array();
-      foreach (array_diff(glob($video_dev_pref."*"), $video_dev_blacklist) as $filename) {
-        $retval = null;
-        $output = null;
-        exec("v4l-info ".escapeshellarg($filename)." 2>/dev/null", $output);
-        if (!$retval) {
-          if (findVideoCaptureBlock($output)) {
-            $cameras[substr($filename, strlen($video_dev_pref), 100)] = TRUE;
-          }
-        }
-      }
+      $cameras = getCameras($video_dev_glob, $rulesets);
       if (!array_key_exists(strval($camera), $cameras)) {
         $first_cam = array_key_first($cameras);
         if ($first_cam != NULL) {
@@ -80,9 +51,6 @@ if ($homepage)
   <a href="./?camera=<?php echo $camera . ($fullscreen ? "" : "&fullscreen") ?>">
     <img data-src="camera.php?id=<?php echo $camera ?>&amp;full" id="mainCamera" class="camera">
   </a>
-  <?php
-    unset($cameras[$camera]);
-  ?>
     <div class="othercameras">
       <?php foreach($cameras as $c => $_) { ?>
         <a href="./?camera=<?php echo $c ?>">


### PR DESCRIPTION
Some cameras (e.g. Genius iSlim 1322AF) takes couple of seconds/frames until they settle on autofocused images. Default command "streamer" doesn't have an option to wait.

This change introduces alternative command - "fswebcam" - for those cameras that are explicitly listed as keys of associative array fswebcam_args. Value of the array is list of arguments to append to default fswebcam args.